### PR TITLE
Removed -K parameter from the tuby calls

### DIFF
--- a/Commands/Create TAGS file.tmCommand
+++ b/Commands/Create TAGS file.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby -wU
 
 require ENV['TM_SUPPORT_PATH'] + '/lib/textmate.rb'
 

--- a/Commands/Jump to tag.tmCommand
+++ b/Commands/Jump to tag.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -wKU
+	<string>#!/usr/bin/env ruby -wU
 
 require ENV['TM_SUPPORT_PATH'] + '/lib/ui.rb'
 


### PR DESCRIPTION
This will prevent a warning when using Ruby 2.0 as the Current Ruby framework.
